### PR TITLE
Decouple as much HttpContext as possible

### DIFF
--- a/src/SoundInTheory.DynamicImage.Extensions.ContentAwareResizing/Filters/ContentAwareResizeFilter.cs
+++ b/src/SoundInTheory.DynamicImage.Extensions.ContentAwareResizing/Filters/ContentAwareResizeFilter.cs
@@ -36,7 +36,7 @@ namespace SoundInTheory.DynamicImage.Filters
 
 		#endregion
 
-        public override void ApplyFilter(ImageGenerationContext context, FastBitmap bitmap)
+        public override void ApplyFilter(FastBitmap bitmap)
 		{
 			if (Width == Unit.Empty && Height == Unit.Empty)
 				throw new DynamicImageException("At least one of Width or Height must be set.");

--- a/src/SoundInTheory.DynamicImage.Extensions.ContentAwareResizing/Util/CairWrapper.cs
+++ b/src/SoundInTheory.DynamicImage.Extensions.ContentAwareResizing/Util/CairWrapper.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Web;
 using SoundInTheory.DynamicImage.Filters;
+using SoundInTheory.DynamicImage.Configuration;
 
 namespace SoundInTheory.DynamicImage.Util
 {
@@ -13,9 +14,9 @@ namespace SoundInTheory.DynamicImage.Util
 	{
 		private static string GetCairFolder()
 		{
-			string folder = (HttpContext.Current == null)
+            string folder = (string.IsNullOrEmpty(DynamicImageSettings.ServerPath))
 				? Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "CAIR")
-				: HttpContext.Current.Server.MapPath("~/App_Data/CAIR");
+                : FileSourceHelper.FilePathOnServer("~/App_Data/CAIR");
 			if (!Directory.Exists(folder))
 				Directory.CreateDirectory(folder);
 			return folder;

--- a/src/SoundInTheory.DynamicImage.Extensions.Pdf/Layers/PdfLayer.cs
+++ b/src/SoundInTheory.DynamicImage.Extensions.Pdf/Layers/PdfLayer.cs
@@ -22,15 +22,15 @@ namespace SoundInTheory.DynamicImage.Layers
 			get { return true; }
 		}
 
-		protected override void CreateImage(ImageGenerationContext context)
+        protected override void CreateImage()
 		{
-			GhostscriptUtil.EnsureDll(context);
+			GhostscriptUtil.EnsureDll();
 
 			string outputFileName = Path.GetTempFileName();
 
 			try
 			{
-				string filename = FileSourceHelper.ResolveFileName(context, SourceFileName);
+				string filename = FileSourceHelper.ResolveFileName(SourceFileName);
 				GhostscriptWrapper.GeneratePageThumb(filename, outputFileName, PageNumber, 96, 96);
 				Bitmap = new FastBitmap(File.ReadAllBytes(outputFileName));
 			}

--- a/src/SoundInTheory.DynamicImage.Extensions.Pdf/Util/GhostscriptUtil.cs
+++ b/src/SoundInTheory.DynamicImage.Extensions.Pdf/Util/GhostscriptUtil.cs
@@ -1,15 +1,16 @@
-﻿using System;
+﻿using SoundInTheory.DynamicImage.Configuration;
+using System;
 using System.IO;
 
 namespace SoundInTheory.DynamicImage.Util
 {
 	internal static class GhostscriptUtil
 	{
-		public static void EnsureDll(ImageGenerationContext context)
+        public static void EnsureDll()
 		{
-			string folder = (context.HttpContext == null)
+            string folder = (string.IsNullOrEmpty(DynamicImageSettings.ServerPath))
 				? AppDomain.CurrentDomain.BaseDirectory
-				: context.HttpContext.Server.MapPath("~/bin");
+                : string.Format("{0}\bin", DynamicImageSettings.ServerPath);
 
 			string gsDllPath = Path.Combine(folder, "gsdll.dll");
 

--- a/src/SoundInTheory.DynamicImage.Extensions.Rendered3D/FileSceneSource.cs
+++ b/src/SoundInTheory.DynamicImage.Extensions.Rendered3D/FileSceneSource.cs
@@ -15,9 +15,9 @@ namespace SoundInTheory.DynamicImage
 			set { this["FileName"] = value; }
 		}
 
-		public override Scene GetScene(ImageGenerationContext context)
+        public override Scene GetScene()
 		{
-			string resolvedFileName = FileSourceHelper.ResolveFileName(context, FileName);
+			string resolvedFileName = FileSourceHelper.ResolveFileName(FileName);
 			if (File.Exists(resolvedFileName))
 				return MeshellatorLoader.ImportFromFile(resolvedFileName);
 			return null;

--- a/src/SoundInTheory.DynamicImage.Extensions.Rendered3D/InlineSceneSource.cs
+++ b/src/SoundInTheory.DynamicImage.Extensions.Rendered3D/InlineSceneSource.cs
@@ -18,7 +18,7 @@ namespace SoundInTheory.DynamicImage
 			Meshes = new MeshCollection();
 		}
 
-		public override Scene GetScene(ImageGenerationContext context)
+        public override Scene GetScene()
 		{
 			Scene scene = new Scene();
 
@@ -37,7 +37,7 @@ namespace SoundInTheory.DynamicImage
 				meshellatorMaterial.DiffuseColor = ConversionUtility.ToNexusColorRgbF(mesh.Material.DiffuseColor);
 				if (!string.IsNullOrEmpty(mesh.Material.TextureFileName))
 				{
-					string textureFileName = FileSourceHelper.ResolveFileName(context, mesh.Material.TextureFileName);
+					string textureFileName = FileSourceHelper.ResolveFileName(mesh.Material.TextureFileName);
 					if (!File.Exists(textureFileName))
 						throw new DynamicImageException("Could not find texture '" + mesh.Material.TextureFileName + "'.");
 					meshellatorMaterial.DiffuseTextureName = textureFileName;

--- a/src/SoundInTheory.DynamicImage.Extensions.Rendered3D/Layers/RenderedLayer.cs
+++ b/src/SoundInTheory.DynamicImage.Extensions.Rendered3D/Layers/RenderedLayer.cs
@@ -75,9 +75,9 @@ namespace SoundInTheory.DynamicImage.Layers
 
 		#endregion
 
-		protected override void CreateImage(ImageGenerationContext context)
+        protected override void CreateImage()
 		{
-			Scene scene = Source.GetScene(context);
+			Scene scene = Source.GetScene();
 			using (var renderer = new WarpSceneRenderer(scene, Width, Height))
 			{
 				renderer.Initialize();

--- a/src/SoundInTheory.DynamicImage.Extensions.Rendered3D/SceneSource.cs
+++ b/src/SoundInTheory.DynamicImage.Extensions.Rendered3D/SceneSource.cs
@@ -7,7 +7,7 @@ namespace SoundInTheory.DynamicImage
 {
 	public abstract class SceneSource : DirtyTrackingObject
 	{
-		public abstract Scene GetScene(ImageGenerationContext context);
+        public abstract Scene GetScene();
 
 		public virtual void PopulateDependencies(List<Dependency> dependencies) { }
 	}

--- a/src/SoundInTheory.DynamicImage.Extensions.WebsiteScreenshot/Layers/WebsiteScreenshotLayer.cs
+++ b/src/SoundInTheory.DynamicImage.Extensions.WebsiteScreenshot/Layers/WebsiteScreenshotLayer.cs
@@ -34,7 +34,7 @@ namespace SoundInTheory.DynamicImage.Layers
 			get { return true; }
 		}
 
-		protected override void CreateImage(ImageGenerationContext context)
+        protected override void CreateImage()
 		{
 			string outputFileName = Path.GetTempFileName();
 

--- a/src/SoundInTheory.DynamicImage.Extensions.WebsiteScreenshot/Util/CutyCaptWrapper.cs
+++ b/src/SoundInTheory.DynamicImage.Extensions.WebsiteScreenshot/Util/CutyCaptWrapper.cs
@@ -1,3 +1,4 @@
+using SoundInTheory.DynamicImage.Configuration;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -13,9 +14,9 @@ namespace SoundInTheory.DynamicImage.Util
 	{
 		private static string GetCairFolder()
 		{
-			string folder = (HttpContext.Current == null)
+            string folder = (string.IsNullOrEmpty(DynamicImageSettings.ServerPath))
 				? Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "CutyCapt")
-				: HttpContext.Current.Server.MapPath("~/App_Data/CutyCapt");
+				: FileSourceHelper.FilePathOnServer("~/App_Data/CutyCapt");
 			if (!Directory.Exists(folder))
 				Directory.CreateDirectory(folder);
 			return folder;

--- a/src/SoundInTheory.DynamicImage.Tests/Filters/CropFilterTests.cs
+++ b/src/SoundInTheory.DynamicImage.Tests/Filters/CropFilterTests.cs
@@ -19,7 +19,7 @@ namespace SoundInTheory.DynamicImage.Tests.Filters
 			cropFilter.Width = 200;
 			cropFilter.Height = 200;
 
-			cropFilter.ApplyFilter(null, bitmap);
+			cropFilter.ApplyFilter(bitmap);
 
 			Assert.AreEqual(200, bitmap.Width);
 			Assert.AreEqual(200, bitmap.Height);

--- a/src/SoundInTheory.DynamicImage.Tests/Filters/ResizeFilterTests.cs
+++ b/src/SoundInTheory.DynamicImage.Tests/Filters/ResizeFilterTests.cs
@@ -20,7 +20,7 @@ namespace SoundInTheory.DynamicImage.Tests.Filters
 			};
 
 			// Act.
-			resizeFilter.ApplyFilter(null, bitmap);
+			resizeFilter.ApplyFilter(bitmap);
 
 			// Assert.
 			Assert.AreEqual(200, bitmap.Width);
@@ -39,7 +39,7 @@ namespace SoundInTheory.DynamicImage.Tests.Filters
 			};
 
 			// Act.
-            resizeFilter.ApplyFilter(null, bitmap);
+            resizeFilter.ApplyFilter(bitmap);
 
 			// Assert.
 			Assert.AreEqual(300, bitmap.Width);
@@ -59,7 +59,7 @@ namespace SoundInTheory.DynamicImage.Tests.Filters
 			};
 
 			// Act.
-            resizeFilter.ApplyFilter(null, bitmap);
+            resizeFilter.ApplyFilter(bitmap);
 
 			// Assert.
 			Assert.AreEqual(250, bitmap.Width);
@@ -79,7 +79,7 @@ namespace SoundInTheory.DynamicImage.Tests.Filters
 			};
 
 			// Act.
-            resizeFilter.ApplyFilter(null, bitmap);
+            resizeFilter.ApplyFilter(bitmap);
 
 			// Assert.
 			Assert.AreEqual(200, bitmap.Width);
@@ -99,7 +99,7 @@ namespace SoundInTheory.DynamicImage.Tests.Filters
 			};
 
 			// Act.
-            resizeFilter.ApplyFilter(null, bitmap);
+            resizeFilter.ApplyFilter(bitmap);
 
 			// Assert.
 			Assert.AreEqual(150, bitmap.Width);
@@ -119,7 +119,7 @@ namespace SoundInTheory.DynamicImage.Tests.Filters
 			};
 
 			// Act.
-            resizeFilter.ApplyFilter(null, bitmap);
+            resizeFilter.ApplyFilter(bitmap);
 
 			// Assert.
 			Assert.AreEqual(250, bitmap.Width);

--- a/src/SoundInTheory.DynamicImage.Website/Html/HtmlHelperExtensions.cs
+++ b/src/SoundInTheory.DynamicImage.Website/Html/HtmlHelperExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Web.Mvc;
 using System.Web.Mvc.Html;
 using SoundInTheory.DynamicImage.Fluent;
+using System.Web;
 
 namespace SoundInTheory.DynamicImage.Website.Html
 {

--- a/src/SoundInTheory.DynamicImage.Website/Views/GettingStarted/Caching.cshtml
+++ b/src/SoundInTheory.DynamicImage.Website/Views/GettingStarted/Caching.cshtml
@@ -48,8 +48,7 @@ public abstract class DynamicImageCacheProvider : ProviderBase
 	public abstract void RemoveAllFromCache();
 	public abstract void RemoveFromCache(Dependency dependency);
 
-	public abstract DateTime GetImageLastModifiedDate(HttpContext context, 
-		string cacheKey, string fileExtension);
+	public abstract DateTime GetImageLastModifiedDate(string cacheKey, string fileExtension);
 	public abstract void SendImageToHttpResponse(HttpContext context, 
 		string cacheKey, string fileExtension);
 }

--- a/src/SoundInTheory.DynamicImage/Caching/DynamicImageCacheManager.cs
+++ b/src/SoundInTheory.DynamicImage/Caching/DynamicImageCacheManager.cs
@@ -91,31 +91,31 @@ namespace SoundInTheory.DynamicImage.Caching
 			}
 		}
 
-		internal static bool Exists(string cacheKey)
+        internal static bool Exists(string cacheKey)
 		{
 			return Provider.ExistsInCache(cacheKey);
 		}
 
-		internal static void Add(string cacheKey, GeneratedImage generatedImage, Dependency[] dependencies)
+        internal static void Add(string cacheKey, GeneratedImage generatedImage, Dependency[] dependencies)
 		{
 			Provider.AddToCache(cacheKey, generatedImage, dependencies);
 		}
 
-		internal static DateTime GetImageLastModifiedDate(HttpContext context, string cacheProviderKey, string fileExtension)
+		internal static DateTime GetImageLastModifiedDate(string cacheProviderKey, string fileExtension)
 		{
-			return Provider.GetImageLastModifiedDate(context, cacheProviderKey, fileExtension);
+			return Provider.GetImageLastModifiedDate(cacheProviderKey, fileExtension);
 		}
 
-		internal static ImageProperties GetProperties(string cacheKey)
+        internal static ImageProperties GetProperties(string cacheKey)
 		{
 			return Provider.GetPropertiesFromCache(cacheKey);
 		}
 
-		public static void Remove(ImageSource source)
+        public static void Remove(ImageSource source)
 		{
 			var dependencies = new List<Dependency>();
 			source.PopulateDependencies(dependencies);
-			dependencies.ForEach(RemoveByDependency);
+            dependencies.ForEach(RemoveByDependency);
 		}
 
 		public static void RemoveAll()
@@ -123,7 +123,7 @@ namespace SoundInTheory.DynamicImage.Caching
 			Provider.RemoveAllFromCache();
 		}
 
-		private static void RemoveByDependency(Dependency dependency)
+        private static void RemoveByDependency(Dependency dependency)
 		{
 			Provider.RemoveFromCache(dependency);
 		}

--- a/src/SoundInTheory.DynamicImage/Caching/DynamicImageCacheProvider.cs
+++ b/src/SoundInTheory.DynamicImage/Caching/DynamicImageCacheProvider.cs
@@ -7,12 +7,12 @@ namespace SoundInTheory.DynamicImage.Caching
 	public abstract class DynamicImageCacheProvider : ProviderBase
 	{
 		public abstract bool ExistsInCache(string cacheKey);
-		public abstract void AddToCache(string cacheKey, GeneratedImage generatedImage, Dependency[] dependencies);
-		public abstract ImageProperties GetPropertiesFromCache(string cacheKey);
+        public abstract void AddToCache(string cacheKey, GeneratedImage generatedImage, Dependency[] dependencies);
+        public abstract ImageProperties GetPropertiesFromCache(string cacheKey);
 		public abstract void RemoveAllFromCache();
-		public abstract void RemoveFromCache(Dependency dependency);
+        public abstract void RemoveFromCache(Dependency dependency);
 
-		public abstract DateTime GetImageLastModifiedDate(HttpContext context, string cacheKey, string fileExtension);
+		public abstract DateTime GetImageLastModifiedDate(string cacheKey, string fileExtension);
 		public abstract void SendImageToHttpResponse(HttpContext context, string cacheKey, string fileExtension);
 	}
 }

--- a/src/SoundInTheory.DynamicImage/Caching/ImageUrlGenerator.cs
+++ b/src/SoundInTheory.DynamicImage/Caching/ImageUrlGenerator.cs
@@ -5,7 +5,7 @@ namespace SoundInTheory.DynamicImage.Caching
 {
 	public static class ImageUrlGenerator
 	{
-		public static string GetImageUrl(Composition composition)
+        public static string GetImageUrl(Composition composition)
 		{
 			string cacheKey = composition.GetCacheKey();
 

--- a/src/SoundInTheory.DynamicImage/Caching/InProcDynamicImageCacheProvider.cs
+++ b/src/SoundInTheory.DynamicImage/Caching/InProcDynamicImageCacheProvider.cs
@@ -15,12 +15,12 @@ namespace SoundInTheory.DynamicImage.Caching
 			get { return _cache ?? (_cache = HttpRuntime.Cache); }
 		}
 
-		public override bool ExistsInCache(string cacheKey)
+        public override bool ExistsInCache(string cacheKey)
 		{
 			return (Cache.Get(cacheKey) != null);
 		}
 
-		public override void AddToCache(string cacheKey, GeneratedImage generatedImage, Dependency[] dependencies)
+        public override void AddToCache(string cacheKey, GeneratedImage generatedImage, Dependency[] dependencies)
 		{
 			InProcCacheEntry cacheEntry = new InProcCacheEntry
 			{
@@ -30,7 +30,7 @@ namespace SoundInTheory.DynamicImage.Caching
 			Cache.Insert(cacheKey, cacheEntry);
 		}
 
-		public override ImageProperties GetPropertiesFromCache(string cacheKey)
+        public override ImageProperties GetPropertiesFromCache(string cacheKey)
 		{
 			return ((InProcCacheEntry)Cache.Get(cacheKey)).GeneratedImage.Properties;
 		}
@@ -41,7 +41,7 @@ namespace SoundInTheory.DynamicImage.Caching
 				.ForEach(de => Cache.Remove((string) de.Key));
 		}
 
-		public override void RemoveFromCache(Dependency dependency)
+        public override void RemoveFromCache(Dependency dependency)
 		{
 			foreach (var dictionaryEntry in Cache.Cast<DictionaryEntry>().Where(de => de.Value is InProcCacheEntry))
 			{
@@ -51,7 +51,7 @@ namespace SoundInTheory.DynamicImage.Caching
 			}
 		}
 
-		public override DateTime GetImageLastModifiedDate(HttpContext context, string cacheKey, string fileExtension)
+		public override DateTime GetImageLastModifiedDate(string cacheKey, string fileExtension)
 		{
 			return DateTime.Now;
 		}

--- a/src/SoundInTheory.DynamicImage/Caching/TransientCacheProvider.cs
+++ b/src/SoundInTheory.DynamicImage/Caching/TransientCacheProvider.cs
@@ -7,7 +7,7 @@ namespace SoundInTheory.DynamicImage.Caching
 	/// </summary>
 	internal class TransientCacheProvider : InProcDynamicImageCacheProvider
 	{
-		public override bool ExistsInCache(string cacheKey)
+        public override bool ExistsInCache(string cacheKey)
 		{
 			return false;
 		}

--- a/src/SoundInTheory.DynamicImage/Caching/XmlCacheProvider.cs
+++ b/src/SoundInTheory.DynamicImage/Caching/XmlCacheProvider.cs
@@ -1,3 +1,5 @@
+using SoundInTheory.DynamicImage.Configuration;
+using SoundInTheory.DynamicImage.Util;
 using System;
 using System.IO;
 using System.Linq;
@@ -12,11 +14,11 @@ namespace SoundInTheory.DynamicImage.Caching
 		private FileSystemWatcher _watcher;
 		private XDocument _doc;
 
-		public override void Initialize(string name, System.Collections.Specialized.NameValueCollection config)
-		{
-			base.Initialize(name, config);
+        public override void Initialize(string name, System.Collections.Specialized.NameValueCollection config)
+        {
+            base.Initialize(name, config);
 
-			_docPath = HttpContext.Current.Server.MapPath(string.Format("{0}/DynamicImageCache.xml", CachePath));
+            _docPath = FileSourceHelper.FilePathOnServer(string.Format("{0}/DynamicImageCache.xml", CachePath));
 			EnsureDocument();
 
 			_watcher = new FileSystemWatcher(Path.GetDirectoryName(_docPath), "DynamicImageCache.xml");
@@ -29,11 +31,11 @@ namespace SoundInTheory.DynamicImage.Caching
 				_watcher.Dispose();
 		}
 
-		private void EnsureDocument()
+        private void EnsureDocument()
 		{
 			lock (this)
 			{
-				string imageCacheFolder = HttpContext.Current.Server.MapPath(CachePath);
+                string imageCacheFolder = FileSourceHelper.FilePathOnServer(CachePath);
 				if (!Directory.Exists(imageCacheFolder))
 					Directory.CreateDirectory(imageCacheFolder);
 
@@ -95,7 +97,7 @@ namespace SoundInTheory.DynamicImage.Caching
 			}
 		}
 
-		public override ImageProperties GetPropertiesFromCache(string cacheKey)
+        public override ImageProperties GetPropertiesFromCache(string cacheKey)
 		{
 			EnsureDocument();
 
@@ -145,12 +147,12 @@ namespace SoundInTheory.DynamicImage.Caching
 					string cacheKey;
 					ImageProperties imageProperties;
 					GetImageProperties(itemElement, out cacheKey, out imageProperties);
-					DeleteImageFromDiskCache(cacheKey, imageProperties , HttpContext.Current);
+					DeleteImageFromDiskCache(cacheKey, imageProperties);
 					itemElement.Remove();
 				}
 				_doc.Save(_docPath);
 			}
-		}
+        }
 
 		public override void RemoveFromCache(Dependency dependency)
 		{
@@ -169,7 +171,7 @@ namespace SoundInTheory.DynamicImage.Caching
 					string cacheKey;
 					ImageProperties imageProperties;
 					GetImageProperties(itemElement, out cacheKey, out imageProperties);
-					DeleteImageFromDiskCache(cacheKey, imageProperties, HttpContext.Current);
+					DeleteImageFromDiskCache(cacheKey, imageProperties);
 					itemElement.Remove();
 				}
 

--- a/src/SoundInTheory.DynamicImage/Configuration/DynamicImageSettings.cs
+++ b/src/SoundInTheory.DynamicImage/Configuration/DynamicImageSettings.cs
@@ -1,0 +1,23 @@
+﻿namespace SoundInTheory.DynamicImage.Configuration
+{
+    public static class DynamicImageSettings
+    {
+        public static void Init(string serverPath)
+        {
+            if(string.IsNullOrEmpty(ServerPath))
+            {
+                _serverPath = serverPath;
+            }
+        }
+
+        private static string _serverPath;
+
+        public static string ServerPath
+        {
+            get
+            {
+                return _serverPath;
+            }
+        }
+    }
+}

--- a/src/SoundInTheory.DynamicImage/DynamicImageModule.cs
+++ b/src/SoundInTheory.DynamicImage/DynamicImageModule.cs
@@ -12,10 +12,13 @@ namespace SoundInTheory.DynamicImage
 	///</summary>
 	public class DynamicImageModule : IHttpModule
 	{
-		public void Init(HttpApplication context)
+        public void Init(HttpApplication context)
 		{
 			context.PostAuthorizeRequest += OnContextPostAuthorizeRequest;
 			context.PreSendRequestHeaders += OnContextPreSendRequestHeaders;
+
+            if (HttpContext.Current != null && HttpContext.Current.Server != null)
+                DynamicImageSettings.Init(HttpContext.Current.Server.MapPath("~"));
 		}
 
 		private static void OnContextPreSendRequestHeaders(object sender, EventArgs e)
@@ -77,7 +80,7 @@ namespace SoundInTheory.DynamicImage
 			DynamicImageSection config = (DynamicImageSection) ConfigurationManager.GetSection("soundInTheory/dynamicImage");
 			if (config != null && config.BrowserCaching != null && config.BrowserCaching.Enabled)
 			{
-				DateTime tempDate = DynamicImageCacheManager.GetImageLastModifiedDate(context, cacheProviderKey, fileExtension);
+				DateTime tempDate = DynamicImageCacheManager.GetImageLastModifiedDate(cacheProviderKey, fileExtension);
 				DateTime lastModifiedDate = new DateTime(tempDate.Year, tempDate.Month, tempDate.Day, tempDate.Hour, tempDate.Minute,
 					tempDate.Second, 0); // This code copied from System.Web.StaticFileHandler.ProcessRequestInternal
 				DateTime now = DateTime.Now;

--- a/src/SoundInTheory.DynamicImage/Filters/BrightnessAdjustmentFilter.cs
+++ b/src/SoundInTheory.DynamicImage/Filters/BrightnessAdjustmentFilter.cs
@@ -30,7 +30,7 @@ namespace SoundInTheory.DynamicImage.Filters
 
 		#region Methods
 
-        protected override Effect GetEffect(ImageGenerationContext context, FastBitmap source)
+        protected override Effect GetEffect(FastBitmap source)
 		{
 			return new BrightnessAdjustmentEffect
 			{

--- a/src/SoundInTheory.DynamicImage/Filters/ClippingMaskFilter.cs
+++ b/src/SoundInTheory.DynamicImage/Filters/ClippingMaskFilter.cs
@@ -49,9 +49,9 @@ namespace SoundInTheory.DynamicImage.Filters
 
 		#region Methods
 
-		protected override Effect GetEffect(ImageGenerationContext context, FastBitmap source)
+        protected override Effect GetEffect(FastBitmap source)
 		{
-            FastBitmap maskBitmap = MaskImage.GetBitmap(context);
+            FastBitmap maskBitmap = MaskImage.GetBitmap();
 			_maskImageWidth = maskBitmap.Width;
 			_maskImageHeight = maskBitmap.Height;
 			return new ClippingMaskEffect

--- a/src/SoundInTheory.DynamicImage/Filters/ColorKeyFilter.cs
+++ b/src/SoundInTheory.DynamicImage/Filters/ColorKeyFilter.cs
@@ -42,7 +42,7 @@ namespace SoundInTheory.DynamicImage.Filters
 
 		#endregion
 
-		protected override Effect GetEffect(ImageGenerationContext context, FastBitmap source)
+        protected override Effect GetEffect(FastBitmap source)
 		{
 			SWMColor transparentColor;
 			if (UseFirstPixel)

--- a/src/SoundInTheory.DynamicImage/Filters/ColorTintFilter.cs
+++ b/src/SoundInTheory.DynamicImage/Filters/ColorTintFilter.cs
@@ -39,7 +39,7 @@ namespace SoundInTheory.DynamicImage.Filters
 
 		#region Methods
 
-        protected override Effect GetEffect(ImageGenerationContext context, FastBitmap source)
+        protected override Effect GetEffect(FastBitmap source)
 		{
 			return new ColorTintEffect
 			{

--- a/src/SoundInTheory.DynamicImage/Filters/ContrastAdjustmentFilter.cs
+++ b/src/SoundInTheory.DynamicImage/Filters/ContrastAdjustmentFilter.cs
@@ -30,7 +30,7 @@ namespace SoundInTheory.DynamicImage.Filters
 
 		#region Methods
 
-        protected override Effect GetEffect(ImageGenerationContext context, FastBitmap source)
+        protected override Effect GetEffect(FastBitmap source)
 		{
 			return new ContrastAdjustmentEffect
 			{

--- a/src/SoundInTheory.DynamicImage/Filters/CropFilter.cs
+++ b/src/SoundInTheory.DynamicImage/Filters/CropFilter.cs
@@ -81,6 +81,12 @@ namespace SoundInTheory.DynamicImage.Filters
 
 		protected override void ApplyFilter(FastBitmap source, DrawingContext dc, int width, int height)
 		{
+            if (Width > source.Width)
+                Width = source.Width;
+
+            if (Height > source.Height)
+                Height = source.Height;
+
 			BitmapSource bitmapSource = new CroppedBitmap(source.InnerBitmap, new System.Windows.Int32Rect(X, Y, Width, Height));
 			dc.DrawImage(bitmapSource, new System.Windows.Rect(0, 0, width, height));
 		}

--- a/src/SoundInTheory.DynamicImage/Filters/CurvesAdjustmentFilter.cs
+++ b/src/SoundInTheory.DynamicImage/Filters/CurvesAdjustmentFilter.cs
@@ -32,10 +32,10 @@ namespace SoundInTheory.DynamicImage.Filters
 
 		#endregion
 
-        protected override Effect GetEffect(ImageGenerationContext context, FastBitmap source)
+        protected override Effect GetEffect(FastBitmap source)
 		{
 			// Get curves either from Curves collection or ACV file.
-			CurveCollection curves = GetCurves(context);
+			CurveCollection curves = GetCurves();
 
 			// Check that there are at least 4 curves.
 			if (curves.Count < 4)
@@ -62,10 +62,10 @@ namespace SoundInTheory.DynamicImage.Filters
 			};
 		}
 
-		private CurveCollection GetCurves(ImageGenerationContext context)
+        private CurveCollection GetCurves()
 		{
 			if (!string.IsNullOrEmpty(PhotoshopCurvesFileName))
-				return PhotoshopCurvesReader.ReadPhotoshopCurvesFile(FileSourceHelper.ResolveFileName(context, PhotoshopCurvesFileName));
+				return PhotoshopCurvesReader.ReadPhotoshopCurvesFile(FileSourceHelper.ResolveFileName(PhotoshopCurvesFileName));
 
 			return Curves;
 		}

--- a/src/SoundInTheory.DynamicImage/Filters/DropShadowFilter.cs
+++ b/src/SoundInTheory.DynamicImage/Filters/DropShadowFilter.cs
@@ -61,7 +61,7 @@ namespace SoundInTheory.DynamicImage.Filters
 			return result;
 		}
 
-        protected override Effect GetEffect(ImageGenerationContext context, FastBitmap source)
+        protected override Effect GetEffect(FastBitmap source)
 		{
 			return new DropShadowEffect
 			{

--- a/src/SoundInTheory.DynamicImage/Filters/EmbossFilter.cs
+++ b/src/SoundInTheory.DynamicImage/Filters/EmbossFilter.cs
@@ -49,7 +49,7 @@ namespace SoundInTheory.DynamicImage.Filters
 
 		#region Methods
 
-        protected override Effect GetEffect(ImageGenerationContext context, FastBitmap source)
+        protected override Effect GetEffect(FastBitmap source)
 		{
 			return new EmbossEffect
 			{

--- a/src/SoundInTheory.DynamicImage/Filters/FeatherFilter.cs
+++ b/src/SoundInTheory.DynamicImage/Filters/FeatherFilter.cs
@@ -50,7 +50,7 @@ namespace SoundInTheory.DynamicImage.Filters
 			return true;
 		}
 
-        protected override Effect GetEffect(ImageGenerationContext context, FastBitmap source)
+        protected override Effect GetEffect(FastBitmap source)
 		{
 			// Fill temporary graphics buffer with mask (currently always a rectangle).
 			DrawingVisual dv = new DrawingVisual

--- a/src/SoundInTheory.DynamicImage/Filters/Filter.cs
+++ b/src/SoundInTheory.DynamicImage/Filters/Filter.cs
@@ -20,6 +20,6 @@ namespace SoundInTheory.DynamicImage.Filters
 	    /// <param name="context"></param>
 	    /// <param name="bitmap">Image to apply the 
 	    /// <see cref="SoundInTheory.DynamicImage.Filters.Filter" /> to.</param>
-	    public abstract void ApplyFilter(ImageGenerationContext context, FastBitmap bitmap);
+        public abstract void ApplyFilter(FastBitmap bitmap);
 	}
 }

--- a/src/SoundInTheory.DynamicImage/Filters/GaussianBlurFilter.cs
+++ b/src/SoundInTheory.DynamicImage/Filters/GaussianBlurFilter.cs
@@ -29,7 +29,7 @@ namespace SoundInTheory.DynamicImage.Filters
 
 		#endregion
 
-        protected override Effect GetEffect(ImageGenerationContext context, FastBitmap source)
+        protected override Effect GetEffect(FastBitmap source)
 		{
 			return new BlurEffect
 			{

--- a/src/SoundInTheory.DynamicImage/Filters/GrayscaleFilter.cs
+++ b/src/SoundInTheory.DynamicImage/Filters/GrayscaleFilter.cs
@@ -9,7 +9,7 @@ namespace SoundInTheory.DynamicImage.Filters
 	/// </summary>
 	public class GrayscaleFilter : ShaderEffectFilter
 	{
-        protected override Effect GetEffect(ImageGenerationContext context, FastBitmap source)
+        protected override Effect GetEffect(FastBitmap source)
 		{
 			return new GrayscaleEffect();
 		}

--- a/src/SoundInTheory.DynamicImage/Filters/ImageReplacementFilter.cs
+++ b/src/SoundInTheory.DynamicImage/Filters/ImageReplacementFilter.cs
@@ -23,7 +23,7 @@ namespace SoundInTheory.DynamicImage.Filters
 	    /// <param name="bitmap">
 	    /// Image to apply the <see cref="ImageReplacementFilter" /> to.
 	    /// </param>
-	    public sealed override void ApplyFilter(ImageGenerationContext context, FastBitmap bitmap)
+        public sealed override void ApplyFilter(FastBitmap bitmap)
 		{
 			OnBeginApplyFilter(bitmap);
 
@@ -34,7 +34,7 @@ namespace SoundInTheory.DynamicImage.Filters
 				return;
 
 			DrawingVisual dv = new DrawingVisual();
-			ConfigureDrawingVisual(context, bitmap, dv);
+			ConfigureDrawingVisual(bitmap, dv);
 
 			DrawingContext dc = dv.RenderOpen();
 
@@ -87,7 +87,7 @@ namespace SoundInTheory.DynamicImage.Filters
 	    /// <param name="context"></param>
 	    /// <param name="source"> </param>
 	    /// <param name="drawingVisual"></param>
-	    protected virtual void ConfigureDrawingVisual(ImageGenerationContext context, FastBitmap source, DrawingVisual drawingVisual)
+	    protected virtual void ConfigureDrawingVisual(FastBitmap source, DrawingVisual drawingVisual)
 		{
 			
 		}

--- a/src/SoundInTheory.DynamicImage/Filters/InversionFilter.cs
+++ b/src/SoundInTheory.DynamicImage/Filters/InversionFilter.cs
@@ -9,7 +9,7 @@ namespace SoundInTheory.DynamicImage.Filters
 	/// </summary>
 	public class InversionFilter : ShaderEffectFilter
 	{
-        protected override Effect GetEffect(ImageGenerationContext context, FastBitmap source)
+        protected override Effect GetEffect(FastBitmap source)
 		{
 			return new InversionEffect();
 		}

--- a/src/SoundInTheory.DynamicImage/Filters/OuterGlowFilter.cs
+++ b/src/SoundInTheory.DynamicImage/Filters/OuterGlowFilter.cs
@@ -9,7 +9,7 @@ namespace SoundInTheory.DynamicImage.Filters
 	{
 		#region Methods
 
-        protected override Effect GetEffect(ImageGenerationContext context, FastBitmap source)
+        protected override Effect GetEffect(FastBitmap source)
 		{
 			return new DropShadowEffect
 			{

--- a/src/SoundInTheory.DynamicImage/Filters/SepiaFilter.cs
+++ b/src/SoundInTheory.DynamicImage/Filters/SepiaFilter.cs
@@ -9,7 +9,7 @@ namespace SoundInTheory.DynamicImage.Filters
 	/// </summary>
 	public class SepiaFilter : ShaderEffectFilter
 	{
-        protected override Effect GetEffect(ImageGenerationContext context, FastBitmap source)
+        protected override Effect GetEffect(FastBitmap source)
 		{
 			return new SepiaEffect();
 		}

--- a/src/SoundInTheory.DynamicImage/Filters/ShaderEffectFilter.cs
+++ b/src/SoundInTheory.DynamicImage/Filters/ShaderEffectFilter.cs
@@ -24,13 +24,13 @@ namespace SoundInTheory.DynamicImage.Filters
 			return true;
 		}
 
-		protected override void ConfigureDrawingVisual(ImageGenerationContext context, FastBitmap source, DrawingVisual drawingVisual)
+        protected override void ConfigureDrawingVisual(FastBitmap source, DrawingVisual drawingVisual)
 		{
-			Effect shaderEffect = GetEffect(context, source);
+			Effect shaderEffect = GetEffect(source);
 			drawingVisual.Effect = shaderEffect;
 		}
 
-        protected abstract Effect GetEffect(ImageGenerationContext context, FastBitmap source);
+        protected abstract Effect GetEffect(FastBitmap source);
 
 		protected override void CleanUpDrawingVisual(FastBitmap source, DrawingVisual drawingVisual)
 		{

--- a/src/SoundInTheory.DynamicImage/Filters/TransferFilter.cs
+++ b/src/SoundInTheory.DynamicImage/Filters/TransferFilter.cs
@@ -8,7 +8,7 @@ namespace SoundInTheory.DynamicImage.Filters
 {
 	public abstract class TransferFilter : ShaderEffectFilter
 	{
-		protected override Effect GetEffect(ImageGenerationContext context, FastBitmap source)
+        protected override Effect GetEffect(FastBitmap source)
 		{
 			FastBitmap transferLookup = new FastBitmap(1, 256);
 			transferLookup.Lock();

--- a/src/SoundInTheory.DynamicImage/Filters/TransformFilter.cs
+++ b/src/SoundInTheory.DynamicImage/Filters/TransformFilter.cs
@@ -49,7 +49,7 @@ namespace SoundInTheory.DynamicImage.Filters
 		/// <returns>The transformed rectangle.</returns>
 		protected virtual Int32Rect GetTransformedSpace(Int32Rect rect) { return rect; }
 
-        public sealed override void ApplyFilter(ImageGenerationContext context, FastBitmap bitmap)
+        public sealed override void ApplyFilter(FastBitmap bitmap)
 		{
 			OnBeginApplyFilter(bitmap);
 

--- a/src/SoundInTheory.DynamicImage/Filters/UnsharpMaskFilter.cs
+++ b/src/SoundInTheory.DynamicImage/Filters/UnsharpMaskFilter.cs
@@ -69,7 +69,7 @@ namespace SoundInTheory.DynamicImage.Filters
 			return true;
 		}
 
-        protected override Effect GetEffect(ImageGenerationContext context, FastBitmap source)
+        protected override Effect GetEffect(FastBitmap source)
 		{
 			// Fill temporary graphics buffer with mask (currently always a rectangle).
 			DrawingVisual dv = new DrawingVisual

--- a/src/SoundInTheory.DynamicImage/Fluent/CompositionBuilder.cs
+++ b/src/SoundInTheory.DynamicImage/Fluent/CompositionBuilder.cs
@@ -2,6 +2,7 @@ using System.Configuration;
 using System.Windows.Media.Imaging;
 using SoundInTheory.DynamicImage.Caching;
 using SoundInTheory.DynamicImage.Configuration;
+using System.Web;
 
 namespace SoundInTheory.DynamicImage.Fluent
 {
@@ -14,14 +15,14 @@ namespace SoundInTheory.DynamicImage.Fluent
 			get { return _composition; }
 		}
 
-		public CompositionBuilder()
-		{
-			_composition = new Composition();
+        public CompositionBuilder()
+        {
+            _composition = new Composition();
 
-			var config = (DynamicImageSection) ConfigurationManager.GetSection("soundInTheory/dynamicImage");
-			if (config != null)
-				_composition.ImageFormat = config.DefaultImageFormat;
-		}
+            var config = (DynamicImageSection)ConfigurationManager.GetSection("soundInTheory/dynamicImage");
+            if (config != null)
+                _composition.ImageFormat = config.DefaultImageFormat;
+        }
 
 		public string Url
 		{

--- a/src/SoundInTheory.DynamicImage/Font.cs
+++ b/src/SoundInTheory.DynamicImage/Font.cs
@@ -55,12 +55,12 @@ namespace SoundInTheory.DynamicImage
 
 		#endregion
 
-        public FontDescription GetFontDescription(ImageGenerationContext context)
+        public FontDescription GetFontDescription()
 		{
 			FontFamily fontFamily;
 			if (!string.IsNullOrEmpty(CustomFontFile))
 			{
-                string fontFileName = FileSourceHelper.ResolveFileName(context, CustomFontFile);
+                string fontFileName = FileSourceHelper.ResolveFileName(CustomFontFile);
 				fontFamily = new FontFamily(fontFileName + "#" + Name);
 			}
 			else

--- a/src/SoundInTheory.DynamicImage/Layer.cs
+++ b/src/SoundInTheory.DynamicImage/Layer.cs
@@ -106,17 +106,17 @@ namespace SoundInTheory.DynamicImage
 
 		#endregion
 
-        public void Process(ImageGenerationContext context)
+        public void Process()
 		{
-			CreateImage(context);
+			CreateImage();
 
 			if (Bitmap != null)
 				foreach (Filter filter in Filters)
 					if (filter.Enabled)
-						filter.ApplyFilter(context, Bitmap);
+						filter.ApplyFilter(Bitmap);
 		}
 
-		protected abstract void CreateImage(ImageGenerationContext context);
+        protected abstract void CreateImage();
 
 		public virtual void PopulateDependencies(List<Dependency> dependencies) { }
 	}

--- a/src/SoundInTheory.DynamicImage/Layers/FractalLayer.cs
+++ b/src/SoundInTheory.DynamicImage/Layers/FractalLayer.cs
@@ -60,7 +60,7 @@ namespace SoundInTheory.DynamicImage.Layers
 
 		#endregion
 
-        protected override void CreateImage(ImageGenerationContext context)
+        protected override void CreateImage()
 		{
 			Bitmap = new FastBitmap(Width, Height);
 			Bitmap.Lock();

--- a/src/SoundInTheory.DynamicImage/Layers/ImageLayer.cs
+++ b/src/SoundInTheory.DynamicImage/Layers/ImageLayer.cs
@@ -36,16 +36,16 @@ namespace SoundInTheory.DynamicImage.Layers
 
 		#endregion
 
-		protected override void CreateImage(ImageGenerationContext context)
+        protected override void CreateImage()
 		{
-            FastBitmap sourceValue = this.Source.GetBitmap(context);
+            FastBitmap sourceValue = this.Source.GetBitmap();
 			if (sourceValue != null && sourceValue.InnerBitmap != null)
 			{
 				this.Bitmap = sourceValue;
 			}
 			else if (AlternateSource != null)
 			{
-				sourceValue = this.AlternateSource.GetBitmap(context);
+				sourceValue = this.AlternateSource.GetBitmap();
 				if (sourceValue != null && sourceValue.InnerBitmap != null)
 					this.Bitmap = sourceValue;
 			}

--- a/src/SoundInTheory.DynamicImage/Layers/PolygonShapeLayer.cs
+++ b/src/SoundInTheory.DynamicImage/Layers/PolygonShapeLayer.cs
@@ -14,9 +14,9 @@ namespace SoundInTheory.DynamicImage.Layers
 			set { this["Sides"] = value; }
 		}
 
-        protected sealed override void CreateImage(ImageGenerationContext context)
+        protected sealed override void CreateImage()
 		{
-			base.CreateImage(context);
+			base.CreateImage();
 
 			Rect bounds = new Rect(StrokeWidth / 2, StrokeWidth / 2,
 				CalculatedWidth - StrokeWidth,

--- a/src/SoundInTheory.DynamicImage/Layers/RectangleShapeLayer.cs
+++ b/src/SoundInTheory.DynamicImage/Layers/RectangleShapeLayer.cs
@@ -10,9 +10,9 @@ namespace SoundInTheory.DynamicImage.Layers
 	/// </summary>
 	public class RectangleShapeLayer : ClosedShapeLayer
 	{
-        protected override sealed void CreateImage(ImageGenerationContext context)
+        protected override sealed void CreateImage()
 		{
-			base.CreateImage(context);
+			base.CreateImage();
 
 			Rect bounds = new Rect(StrokeWidth / 2, StrokeWidth / 2,
 				CalculatedWidth - StrokeWidth,

--- a/src/SoundInTheory.DynamicImage/Layers/ShapeLayer.cs
+++ b/src/SoundInTheory.DynamicImage/Layers/ShapeLayer.cs
@@ -56,7 +56,7 @@ namespace SoundInTheory.DynamicImage.Layers
 
 		#endregion
 
-        protected override void CreateImage(ImageGenerationContext context)
+        protected override void CreateImage()
 		{
 			if (this.Width != null)
 				this.CalculatedWidth = this.Width.Value;

--- a/src/SoundInTheory.DynamicImage/Layers/TextLayer.cs
+++ b/src/SoundInTheory.DynamicImage/Layers/TextLayer.cs
@@ -88,11 +88,11 @@ namespace SoundInTheory.DynamicImage.Layers
 
 		#endregion
 
-        protected override void CreateImage(ImageGenerationContext context)
+        protected override void CreateImage()
 		{
 			// If width and height are not set, we need to measure the string.
 			int calculatedWidth, calculatedHeight;
-			Size measuredSize = MeasureString(context);
+			Size measuredSize = MeasureString();
 			if (Width == null || Height == null)
 			{
 				double width = Width ?? measuredSize.Width;
@@ -115,7 +115,7 @@ namespace SoundInTheory.DynamicImage.Layers
 			TextOptions.SetTextRenderingMode(dv, TextRenderingMode.Auto);
 			//TextOptions.SetTextFormattingMode(dv, TextFormattingMode.Ideal)
 
-			UseFormattedText(context, ft =>
+			UseFormattedText(ft =>
 			{
 				Pen pen = null;
 				if (StrokeWidth > 0 && StrokeColor != null)
@@ -178,20 +178,20 @@ namespace SoundInTheory.DynamicImage.Layers
 			}
 		}
 
-		private Size MeasureString(ImageGenerationContext context)
+        private Size MeasureString()
 		{
 			Size size = System.Windows.Size.Empty;
-			UseFormattedText(context, ft =>
+			UseFormattedText(ft =>
 			{
 				size = new Size(ft.WidthIncludingTrailingWhitespace, ft.Height);
 			});
 			return size;
 		}
 
-		private void UseFormattedText(ImageGenerationContext context, RenderCallback renderCallback)
+        private void UseFormattedText(RenderCallback renderCallback)
 		{
 			Brush textBrush = new SolidColorBrush(ForeColor.ToWpfColor());
-			FontDescription fontDescription = Font.GetFontDescription(context);
+			FontDescription fontDescription = Font.GetFontDescription();
 			var formattedText = new FormattedText(
 				Text, CultureInfo.CurrentCulture, FlowDirection.LeftToRight,
 				fontDescription.Typeface, fontDescription.Size, textBrush);

--- a/src/SoundInTheory.DynamicImage/SoundInTheory.DynamicImage.csproj
+++ b/src/SoundInTheory.DynamicImage/SoundInTheory.DynamicImage.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Caching\XmlCacheProvider.cs" />
     <Compile Include="Color.cs" />
     <Compile Include="Colors.cs" />
+    <Compile Include="Configuration\DynamicImageSettings.cs" />
     <Compile Include="Fluent\ColorTintFilterBuilder.cs" />
     <Compile Include="Fluent\FractalLayerBuilder.cs" />
     <Compile Include="Fluent\JuliaFractalLayerBuilder.cs" />
@@ -231,7 +232,6 @@
     <Compile Include="Util\CubicSplineUtility.cs" />
     <Compile Include="Util\DispatcherTaskScheduler.cs" />
     <Compile Include="Util\FastBitmap.cs" />
-    <Compile Include="Util\ImageGenerationContext.cs" />
     <Compile Include="Util\Int32RectUtility.cs" />
     <Compile Include="Util\Int32Size.cs" />
     <Compile Include="Util\MathUtility.cs" />

--- a/src/SoundInTheory.DynamicImage/Sources/BytesImageSource.cs
+++ b/src/SoundInTheory.DynamicImage/Sources/BytesImageSource.cs
@@ -10,7 +10,7 @@ namespace SoundInTheory.DynamicImage.Sources
 			set { this["Bytes"] = value; }
 		}
 
-		public override FastBitmap GetBitmap(ImageGenerationContext context)
+		public override FastBitmap GetBitmap()
 		{
 			byte[] bytes = this.Bytes;
 			if (bytes != null && bytes.Length > 0)

--- a/src/SoundInTheory.DynamicImage/Sources/FileImageSource.cs
+++ b/src/SoundInTheory.DynamicImage/Sources/FileImageSource.cs
@@ -15,9 +15,9 @@ namespace SoundInTheory.DynamicImage.Sources
 			set { this["FileName"] = value; }
 		}
 
-		public override FastBitmap GetBitmap(ImageGenerationContext context)
+		public override FastBitmap GetBitmap()
 		{
-            string resolvedFileName = FileSourceHelper.ResolveFileName(context, FileName);
+            string resolvedFileName = FileSourceHelper.ResolveFileName(FileName);
 			if (File.Exists(resolvedFileName))
 				return new FastBitmap(resolvedFileName);
 			return null;

--- a/src/SoundInTheory.DynamicImage/Sources/ImageImageSource.cs
+++ b/src/SoundInTheory.DynamicImage/Sources/ImageImageSource.cs
@@ -11,7 +11,7 @@ namespace SoundInTheory.DynamicImage.Sources
 			set { this["Image"] = value; }
 		}
 
-        public override FastBitmap GetBitmap(ImageGenerationContext context)
+        public override FastBitmap GetBitmap()
 		{
 			return new FastBitmap(Image);
 		}

--- a/src/SoundInTheory.DynamicImage/Sources/ImageSource.cs
+++ b/src/SoundInTheory.DynamicImage/Sources/ImageSource.cs
@@ -6,7 +6,7 @@ namespace SoundInTheory.DynamicImage.Sources
 {
 	public abstract class ImageSource : DirtyTrackingObject
 	{
-        public abstract FastBitmap GetBitmap(ImageGenerationContext context);
+        public abstract FastBitmap GetBitmap();
 
 		public virtual void PopulateDependencies(List<Dependency> dependencies) { }
 	}

--- a/src/SoundInTheory.DynamicImage/Sources/RemoteImageSource.cs
+++ b/src/SoundInTheory.DynamicImage/Sources/RemoteImageSource.cs
@@ -21,7 +21,7 @@ namespace SoundInTheory.DynamicImage.Sources
             set { this["Timeout"] = value; }
         }
 
-        public override FastBitmap GetBitmap(ImageGenerationContext context)
+        public override FastBitmap GetBitmap()
         {
             using (var webClient = new ImpatientWebClient(Timeout))
             {

--- a/src/SoundInTheory.DynamicImage/Sources/SqlDatabaseImageSource.cs
+++ b/src/SoundInTheory.DynamicImage/Sources/SqlDatabaseImageSource.cs
@@ -58,7 +58,7 @@ namespace SoundInTheory.DynamicImage.Sources
 
 		#endregion
 
-        public override FastBitmap GetBitmap(ImageGenerationContext context)
+        public override FastBitmap GetBitmap()
 		{
 			SqlConnection conn = null; SqlDataAdapter adapter = null; DataTable dt = null;
 			try

--- a/src/SoundInTheory.DynamicImage/Util/FileSourceHelper.cs
+++ b/src/SoundInTheory.DynamicImage/Util/FileSourceHelper.cs
@@ -1,17 +1,28 @@
-﻿using System;
+﻿using SoundInTheory.DynamicImage.Configuration;
+using System;
 using System.IO;
 
 namespace SoundInTheory.DynamicImage.Util
 {
 	public static class FileSourceHelper
 	{
-		public static string ResolveFileName(ImageGenerationContext context, string filename)
+        public static string FilePathOnServer(string filepath)
+        {
+            if (filepath.StartsWith("~/"))
+            {
+                filepath = filepath.Replace("~/", "");
+            }
+            filepath = filepath.Replace("/", @"\");
+
+            return Path.Combine(DynamicImageSettings.ServerPath, filepath);
+        }
+
+		public static string ResolveFileName(string filename)
 		{
 			string fileName = null;
 			if (!Path.IsPathRooted(filename))
 			{
-				if (context.HttpContext != null)
-					fileName = context.HttpContext.Server.MapPath(filename);
+                fileName = FilePathOnServer(filename);
 
 				if (fileName == null)
 					throw new InvalidOperationException("Could not resolve source filename.");


### PR DESCRIPTION
I decoupled as much HttpContext as possible from the libraries. Because I use Dynamic-Image in an async method the library can't relay on HttpContext. It can on the other hand when initializing the library in the Application start, so I made the application save the application path (that's what the context is used for in almost every case) on runtime and use it only on the places where it's needed from this runtime variable.

There isn't any breaking change, hope you like the changes.
