### PR TITLE
Add AnchorPadding with percents to Layer class

### DIFF
--- a/src/SoundInTheory.DynamicImage/Composition.cs
+++ b/src/SoundInTheory.DynamicImage/Composition.cs
@@ -183,12 +183,13 @@ namespace SoundInTheory.DynamicImage
 						case AnchorStyles.BottomLeft :
 						case AnchorStyles.MiddleLeft :
 						case AnchorStyles.TopLeft :
-							layer.X = layer.AnchorPadding;
+							layer.X = layer.AnchorPaddingType == UnitType.Pixel ? layer.AnchorPadding : (int)(layer.AnchorPadding / 100.0 * (outputWidth - layer.Size.Value.Width));
 							break;
 						case AnchorStyles.BottomRight:
 						case AnchorStyles.MiddleRight:
 						case AnchorStyles.TopRight:
-							layer.X = outputWidth - layer.Size.Value.Width - layer.AnchorPadding;
+							layer.X = outputWidth - layer.Size.Value.Width -
+								(layer.AnchorPaddingType == UnitType.Pixel ? layer.AnchorPadding : (int)(layer.AnchorPadding / 100.0 * (outputWidth - layer.Size.Value.Width)));
 							break;
 					}
 
@@ -198,7 +199,8 @@ namespace SoundInTheory.DynamicImage
 						case AnchorStyles.BottomCenter:
 						case AnchorStyles.BottomLeft:
 						case AnchorStyles.BottomRight:
-							layer.Y = outputHeight - layer.Size.Value.Height - layer.AnchorPadding;
+							layer.Y = outputHeight - layer.Size.Value.Height -
+								(layer.AnchorPaddingType == UnitType.Pixel ? layer.AnchorPadding : (int)(layer.AnchorPadding / 100.0 * (outputHeight - layer.Size.Value.Height)));
 							break;
 						case AnchorStyles.MiddleCenter:
 						case AnchorStyles.MiddleLeft:
@@ -208,7 +210,7 @@ namespace SoundInTheory.DynamicImage
 						case AnchorStyles.TopCenter:
 						case AnchorStyles.TopLeft:
 						case AnchorStyles.TopRight:
-							layer.Y = layer.AnchorPadding;
+							layer.Y = layer.AnchorPaddingType == UnitType.Pixel ? layer.AnchorPadding : (int)(layer.AnchorPadding / 100.0 * (outputHeight - layer.Size.Value.Height));
 							break;
 					}
 				}

--- a/src/SoundInTheory.DynamicImage/Fluent/BaseLayerBuilder.cs
+++ b/src/SoundInTheory.DynamicImage/Fluent/BaseLayerBuilder.cs
@@ -63,9 +63,22 @@ namespace SoundInTheory.DynamicImage.Fluent
 			return (TLayerBuilder)this;
 		}
 
+		public TLayerBuilder AnchorPaddingType(UnitType type)
+		{
+			Layer.AnchorPaddingType = type;
+			return (TLayerBuilder)this;
+		}
+
 		public TLayerBuilder AnchorPadding(int padding)
 		{
 			Layer.AnchorPadding = padding;
+			return (TLayerBuilder)this;
+		}
+
+		public TLayerBuilder AnchorPadding(Unit unit)
+		{
+			Layer.AnchorPadding = (int)unit.Value;
+			Layer.AnchorPaddingType = unit.Type;
 			return (TLayerBuilder)this;
 		}
 

--- a/src/SoundInTheory.DynamicImage/Layer.cs
+++ b/src/SoundInTheory.DynamicImage/Layer.cs
@@ -36,8 +36,37 @@ namespace SoundInTheory.DynamicImage
 
 		public int AnchorPadding
 		{
-			get { return (int)(this["AnchorPadding"] ?? 0); }
-			set { this["AnchorPadding"] = value; }
+			get 
+			{
+				if (this["AnchorPadding"] == null)
+				{
+					this["AnchorPadding"] = Unit.Pixel(0);
+				}
+				return (int)((Unit)this["AnchorPadding"]).Value;
+			}
+			set 
+			{
+				this["AnchorPadding"] = (this["AnchorPadding"] == null || ((Unit)this["AnchorPadding"]).Type == UnitType.Pixel) ?
+					Unit.Pixel(value) :
+					Unit.Percentage(value);
+			}
+		}
+
+		public UnitType AnchorPaddingType
+		{
+			get
+			{
+				if (this["AnchorPadding"] == null)
+				{
+					this["AnchorPadding"] = Unit.Pixel(0);
+				}
+				return ((Unit)this["AnchorPadding"]).Type;
+			}
+			set
+			{
+				var currentValue = AnchorPadding;
+				this["AnchorPadding"] = value == UnitType.Pixel ? Unit.Pixel(currentValue) : Unit.Percentage(currentValue);
+			}
 		}
 
 		public Padding Padding


### PR DESCRIPTION
It is possible to set AnchorPadding in pixels or percents relative to the
Composition's width/height.
AnchorPaddingType in Layer specifies unit type of AnchorPadding.
LayerBuilder has overloaded AnchorPadding function that accepts Unit
structure and sets both AnchorPadding and AnchorPaddingType.
AnchorPadding uses pixels by default, API is backwards compatible.

Example of usage: write watermark at the bottom of the image with 30%
"margin":
LayerBuilder.Text.Text("(c) Copyright 2014")
  .Anchor(AnchorStyles.BottomCenter)
  .AnchorPadding(Unit.Percentage(30));
