### PR TITLE
Fixed memory leak

### DIFF
--- a/src/SoundInTheory.DynamicImage/LayerBlender.cs
+++ b/src/SoundInTheory.DynamicImage/LayerBlender.cs
@@ -48,7 +48,6 @@ namespace SoundInTheory.DynamicImage
 					rtb.Render(dv);
 				}
 
-				imageSource = rtb;
 			}
 
 			return new FastBitmap(rtb);


### PR DESCRIPTION
Overwriting the imageSource variable after rendering every layer causes a memory leak. I experienced a lot out of memory exceptions when trying to create large images with many layers that were all image layers. I am not sure why this is the case because the code seems innocuous, but it made a huge difference with large images when taking it out. 
